### PR TITLE
fix(ui): add stroke to player name

### DIFF
--- a/client/src/phaser/entities/player.ts
+++ b/client/src/phaser/entities/player.ts
@@ -26,9 +26,11 @@ export class Player extends Entity {
 
     this.nameText = this.scene.add
       .text(0, -(CELL_SIZE / 2) - 4, name, {
-        fontSize: "24px",
+        fontSize: "26px",
         color: local ? "#ffdd77" : "#fff",
         align: "center",
+        stroke: "#000",
+        strokeThickness: 2,
       })
       .setOrigin(0.5, 1);
     this.add(this.nameText);


### PR DESCRIPTION
Zwiększyłem rozmiar nicku gracza do 26 px i dodałem obrys na strokeThickness: 2. Nie jestem przekonany do tego jak to wygląda, alternatywą może być wstawienie zaokrąglonego prostokąta za nickiem z opacity .3 lub coś podobnego. No ale shadow i stroke dają taki średni efekt przy tak małej czcionce.